### PR TITLE
README: Bump version to 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,5 +166,5 @@ For more information about the upstream Calamares project, visit
 https://calamares.euroquis.nl/
 
 # Release notes
-## Version 1.0.0
+## Version 1.1.0
 Initial release


### PR DESCRIPTION
Labeled the initial release as version 1.1.0, to match the version number of all SEAPATH projects.