### PR TITLE
2.0 release preparation

### DIFF
--- a/src/modules/imageselection/CMakeLists.txt
+++ b/src/modules/imageselection/CMakeLists.txt
@@ -8,6 +8,7 @@ calamares_add_plugin(imageselection
         ImageSelectionViewStep.cpp
     UI
         ImageSelectionPage.ui
+        SeapathFlavorSelection.ui
     LINK_PRIVATE_LIBRARIES
         ${qtname}::DBus
         ${qtname}::Xml

--- a/src/modules/imageselection/CMakeLists.txt
+++ b/src/modules/imageselection/CMakeLists.txt
@@ -10,6 +10,9 @@ calamares_add_plugin(imageselection
         ImageSelectionPage.ui
     LINK_PRIVATE_LIBRARIES
         ${qtname}::DBus
+        ${qtname}::Xml
         z
     SHARED_LIB
 )
+
+find_package(${qtname} ${QT_VERSION} COMPONENTS Xml)

--- a/src/modules/imageselection/ImageSelectionPage.cpp
+++ b/src/modules/imageselection/ImageSelectionPage.cpp
@@ -147,6 +147,7 @@ ImageSelectionPage::scanAvailableImages()
         QString imageDescription;
         QString imageVersion;
         QString imageFlavor;
+        QString imageSetup;
         auto* gs = Calamares::JobQueue::instance()->globalStorage();
 
         bmap.replace(QRegularExpression("(\\.gz)$"), ".bmap");
@@ -166,6 +167,8 @@ ImageSelectionPage::scanAvailableImages()
             item->setText( 0, name );
             item->setText( 1, "Not available" );
             item->setText( 2, "Not available" );
+            item->setText( 3, "Not available" );
+            item->setText( 4, "Not available" );
             item->setFlags( item->flags() | Qt::ItemIsUserCheckable );
             item->setCheckState( 0, Qt::Unchecked );
             item->setData( 0, Qt::UserRole, dir.absoluteFilePath( fn ) ); // Checkbox metadata (hidden)
@@ -207,16 +210,19 @@ ImageSelectionPage::scanAvailableImages()
             imageVersion = getElementText(root, "ImageVersion");
             imageDescription = getElementText(root, "ImageDescription");
             imageFlavor = getElementText(root, "ImageFlavor");
+            imageSetup = getElementText(root, "ImageSetup");
 
             imageVersion = checkEmptyElement(imageVersion);
             imageDescription = checkEmptyElement(imageDescription);
             imageFlavor = checkEmptyElement(imageFlavor);
+            imageSetup = checkEmptyElement(imageSetup);
 
             auto* item = new QTreeWidgetItem( ui->treeWidget );
             item->setText( 0, imageName );
             item->setText( 1, imageFlavor );
-            item->setText( 2, imageVersion );
-            item->setText( 3, imageDescription );
+            item->setText( 2, imageSetup );
+            item->setText( 3, imageVersion );
+            item->setText( 4, imageDescription );
             item->setFlags( item->flags() | Qt::ItemIsUserCheckable );
             item->setCheckState( 0, Qt::Unchecked );
 

--- a/src/modules/imageselection/ImageSelectionPage.cpp
+++ b/src/modules/imageselection/ImageSelectionPage.cpp
@@ -13,6 +13,7 @@
 
 #include "Config.h"
 #include "ui_ImageSelectionPage.h"
+#include "ui_SeapathFlavorSelection.h"
 #include "GlobalStorage.h"
 #include "JobQueue.h"
 
@@ -28,6 +29,9 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QtXml/QDomDocument>
+#include <QPointer>
+#include <QDialog>
+#include <QSignalBlocker>
 
 ImageSelectionPage::ImageSelectionPage( Config* config, QWidget* parent )
     : QWidget( parent )
@@ -67,6 +71,7 @@ ImageSelectionPage::ImageSelectionPage( Config* config, QWidget* parent )
         if ( changed->checkState(0) == Qt::Checked )
         {
             // Enforce single selection (optional)
+            const QSignalBlocker blocker( ui->treeWidget );
             for ( int i = 0; i < ui->treeWidget->topLevelItemCount(); ++i )
             {
                 auto* it = ui->treeWidget->topLevelItem( i );
@@ -89,11 +94,19 @@ ImageSelectionPage::ImageSelectionPage( Config* config, QWidget* parent )
                 selected << it->text(0);
                 selectedFiles << it->data( 0, Qt::UserRole ).toString(); // hidden path
                 cDebug() << "debug:" << selectedFiles;
+
+                seapathFlavor << it->text(1);
+                cDebug() << "Selected SEAPATH flavor:" << seapathFlavor;
+
+                gs->insert( "seapathFlavor", seapathFlavor[0] );
             }
         }
 
         cDebug() << "imageselection: selected images:" << selected;
         cDebug() << "imageselection: selected files:" << selectedFiles;
+
+        if (seapathFlavor.contains("Not available") )
+            confirmSeapathFlavor();
 
         if ( !selected.isEmpty() )
         {
@@ -101,7 +114,6 @@ ImageSelectionPage::ImageSelectionPage( Config* config, QWidget* parent )
 
             gs->insert( "imageselection.selected", selected );
             gs->insert( "imageselection.selectedFiles", selectedFiles );
-            gs->insert( "seapathFlavor", seapathFlavor[0] );
         }
 
         else{
@@ -212,11 +224,26 @@ ImageSelectionPage::scanAvailableImages()
             bmapFile.close();
             continue;
         }
-
-
     }
 }
 
+void
+ImageSelectionPage::confirmSeapathFlavor()
+{
+    QPointer< QDialog > dlg = new QDialog( this );
+    Ui_SeapathFlavorSelection ui;
+    auto* gs = Calamares::JobQueue::instance()->globalStorage();
+
+    ui.setupUi( dlg.data() );
+    dlg->exec();
+
+    auto seapathFlavor = ui.debianRadioButton->isChecked() ? "debian" : "yocto";
+    cDebug() << "Selected SEAPATH flavor:" << seapathFlavor;
+
+    gs->insert( "seapathFlavor", seapathFlavor );
+
+    delete dlg;
+}
 
 void
 ImageSelectionPage::focusInEvent( QFocusEvent* e )

--- a/src/modules/imageselection/ImageSelectionPage.cpp
+++ b/src/modules/imageselection/ImageSelectionPage.cpp
@@ -27,6 +27,7 @@
 #include <QDir>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QtXml/QDomDocument>
 
 ImageSelectionPage::ImageSelectionPage( Config* config, QWidget* parent )
     : QWidget( parent )
@@ -77,6 +78,8 @@ ImageSelectionPage::ImageSelectionPage( Config* config, QWidget* parent )
         // Collect checked items
         QStringList selected;
         QStringList selectedFiles;     // hidden file paths
+        QStringList seapathFlavor;
+        auto* gs = Calamares::JobQueue::instance()->globalStorage();
 
         for ( int i = 0; i < ui->treeWidget->topLevelItemCount(); ++i )
         {
@@ -96,18 +99,9 @@ ImageSelectionPage::ImageSelectionPage( Config* config, QWidget* parent )
         {
             emit selectionChanged( !selected.isEmpty() );
 
-            auto* gs = Calamares::JobQueue::instance()->globalStorage();
             gs->insert( "imageselection.selected", selected );
             gs->insert( "imageselection.selectedFiles", selectedFiles );
-
-            if ( selected[0].toLower().contains("debian") )
-            {
-                gs->insert( "seapathFlavor", "debian" );
-            }
-            else
-            {
-                gs->insert( "seapathFlavor", "yocto" );
-            }
+            gs->insert( "seapathFlavor", seapathFlavor[0] );
         }
 
         else{
@@ -136,61 +130,86 @@ ImageSelectionPage::scanAvailableImages()
     {
         QString gz_image = fn;
         QString json = fn;
+        QString bmap = fn;
+        QString imageName;
+        QString imageDescription;
+        QString imageVersion;
+        QString imageFlavor;
+        auto* gs = Calamares::JobQueue::instance()->globalStorage();
 
-        json.replace(QRegularExpression("\\.(wic\\.gz|raw\\.gz|iso)$"), ".json");
+        bmap.replace(QRegularExpression("(\\.gz)$"), ".bmap");
         gz_image.replace(QRegularExpression("\\.json$"), ".gz");
 
         cDebug() << "imageselection: found" << fn;
-        cDebug() << "imageselection: looking for metadata file" << json;
-        cDebug() << "JSON path:" << dir.absoluteFilePath( json );
-        if ( !QFile::exists( dir.absoluteFilePath( json ) ) )
-        {
-            cDebug() << "imageselection: no metadata file found for" << fn;
-            // Not a JSON file, just add it with minimal info
-            QString name = fn;
-            name.replace(QRegularExpression("\\.(wic\\.gz|raw\\.gz|iso)$"), "");
-            cDebug() << "imageselection: found image" << name << "(non-JSON file)";
-            m_availableImages << name;
+        cDebug() << "imageselection: looking for bmap file" << bmap;
 
+        /* Bmap file not readable/not present
+        --> No metadata support, marked them as 'Not available'
+        */
+        if ( !QFile::exists( dir.absoluteFilePath( bmap ) ) )
+        {
+            cDebug() << "imageselection: no BMAP metadata file found for" << fn;
+            QString name = fn;
             auto* item = new QTreeWidgetItem( ui->treeWidget );
             item->setText( 0, name );
-            item->setText( 1, "-" );
-            item->setText( 2, "(no description available)" );
+            item->setText( 1, "Not available" );
+            item->setText( 2, "Not available" );
             item->setFlags( item->flags() | Qt::ItemIsUserCheckable );
             item->setCheckState( 0, Qt::Unchecked );
-
-            item->setData( 0, Qt::UserRole, dir.absoluteFilePath( gz_image ) );          // original file path
+            item->setData( 0, Qt::UserRole, dir.absoluteFilePath( fn ) ); // Checkbox metadata (hidden)
             continue;
         }
 
         else {
-            QFile jsonFile( dir.absoluteFilePath( json ) );
-            if ( !jsonFile.open( QIODevice::ReadOnly ) )
+            QFile bmapFile( dir.absoluteFilePath( bmap ) );
+            if ( !bmapFile.open( QIODevice::ReadOnly ) )
             {
-                cDebug() << "imageselection: cannot open JSON file" << jsonFile.fileName();
+                cDebug() << "imageselection: cannot open BMAP file" << bmapFile.fileName();
                 continue;
             }
 
-            QJsonParseError pe;
-            QJsonDocument doc = QJsonDocument::fromJson( jsonFile.readAll(), &pe );
+            QDomDocument xmlBMAP;
+            xmlBMAP.setContent(&bmapFile);
 
-            QJsonObject o = doc.object();
-            QString name = o.value( "name" ).toString( fn );
-            QString version = o.value( "version" ).toString( "-" );
-            QString description = o.value( "description" ).toString();
+            QDomElement root=xmlBMAP.documentElement();
 
-            cDebug() << "imageselection: found image" << name << version << description;
-            m_availableImages << name;
+            // Extract value of a XML tag field
+            auto getElementText = [](const QDomElement& parent, const QString& tag) -> QString {
+                QDomElement elem = parent.firstChildElement(tag);
+                return elem.text().trimmed();
+            };
+
+            // If XML tag do not exist mark the value as not available
+            auto checkEmptyElement = [](const QString& tag) -> QString {
+                if(tag == "")
+                    return "Not available";
+                return tag;
+            };
+
+            imageName = getElementText(root, "ImageName");
+
+            // If no image name defined print the image file name
+            if(imageName == "")
+                imageName = fn;
+
+            imageVersion = getElementText(root, "ImageVersion");
+            imageDescription = getElementText(root, "ImageDescription");
+            imageFlavor = getElementText(root, "ImageFlavor");
+
+            imageVersion = checkEmptyElement(imageVersion);
+            imageDescription = checkEmptyElement(imageDescription);
+            imageFlavor = checkEmptyElement(imageFlavor);
 
             auto* item = new QTreeWidgetItem( ui->treeWidget );
-            item->setText( 0, name );
-            item->setText( 1, version );
-            item->setText( 2, description );
+            item->setText( 0, imageName );
+            item->setText( 1, imageFlavor );
+            item->setText( 2, imageVersion );
+            item->setText( 3, imageDescription );
             item->setFlags( item->flags() | Qt::ItemIsUserCheckable );
             item->setCheckState( 0, Qt::Unchecked );
 
-            item->setData( 0, Qt::UserRole, dir.absoluteFilePath( fn ) );          // original JSON file path
-            jsonFile.close();
+            item->setData( 0, Qt::UserRole, dir.absoluteFilePath( fn ) );
+            bmapFile.close();
             continue;
         }
 

--- a/src/modules/imageselection/ImageSelectionPage.cpp
+++ b/src/modules/imageselection/ImageSelectionPage.cpp
@@ -85,6 +85,7 @@ ImageSelectionPage::ImageSelectionPage( Config* config, QWidget* parent )
         QStringList selectedFiles;     // hidden file paths
         QStringList seapathFlavor;
         auto* gs = Calamares::JobQueue::instance()->globalStorage();
+        QStringList noBmap;
 
         for ( int i = 0; i < ui->treeWidget->topLevelItemCount(); ++i )
         {
@@ -97,6 +98,9 @@ ImageSelectionPage::ImageSelectionPage( Config* config, QWidget* parent )
 
                 seapathFlavor << it->text(1);
                 cDebug() << "Selected SEAPATH flavor:" << seapathFlavor;
+
+                noBmap << it->data( 1, Qt::UserRole ).toString();
+                cDebug() << "BMAP provided with image:" << seapathFlavor;
 
                 gs->insert( "seapathFlavor", seapathFlavor[0] );
             }
@@ -114,6 +118,7 @@ ImageSelectionPage::ImageSelectionPage( Config* config, QWidget* parent )
 
             gs->insert( "imageselection.selected", selected );
             gs->insert( "imageselection.selectedFiles", selectedFiles );
+            gs->insert( "noBmap", noBmap[0] );
         }
 
         else{
@@ -172,6 +177,7 @@ ImageSelectionPage::scanAvailableImages()
             item->setFlags( item->flags() | Qt::ItemIsUserCheckable );
             item->setCheckState( 0, Qt::Unchecked );
             item->setData( 0, Qt::UserRole, dir.absoluteFilePath( fn ) ); // Checkbox metadata (hidden)
+            item->setData( 1, Qt::UserRole, true ); // Checkbox metadata (hidden)
             continue;
         }
 
@@ -182,7 +188,7 @@ ImageSelectionPage::scanAvailableImages()
                 cDebug() << "imageselection: cannot open BMAP file" << bmapFile.fileName();
                 continue;
             }
-
+            gs->insert( "False", "noBmap" );
             QDomDocument xmlBMAP;
             xmlBMAP.setContent(&bmapFile);
 
@@ -227,6 +233,7 @@ ImageSelectionPage::scanAvailableImages()
             item->setCheckState( 0, Qt::Unchecked );
 
             item->setData( 0, Qt::UserRole, dir.absoluteFilePath( fn ) );
+            item->setData( 1, Qt::UserRole, false );
             bmapFile.close();
             continue;
         }

--- a/src/modules/imageselection/ImageSelectionPage.h
+++ b/src/modules/imageselection/ImageSelectionPage.h
@@ -36,6 +36,7 @@ public:
 public slots:
     void onInstallationFailed( const QString& message, const QString& details );
     void retranslate();
+    void confirmSeapathFlavor();
 
 
 protected:

--- a/src/modules/imageselection/ImageSelectionPage.ui
+++ b/src/modules/imageselection/ImageSelectionPage.ui
@@ -27,7 +27,7 @@
       <bool>true</bool>
      </property>
      <property name="columnCount">
-      <number>4</number>
+      <number>5</number>
      </property>
      <column>
       <property name="text">
@@ -37,6 +37,11 @@
      <column>
       <property name="text">
        <string>Flavor</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Setup</string>
       </property>
      </column>
      <column>

--- a/src/modules/imageselection/ImageSelectionPage.ui
+++ b/src/modules/imageselection/ImageSelectionPage.ui
@@ -27,11 +27,16 @@
       <bool>true</bool>
      </property>
      <property name="columnCount">
-      <number>3</number>
+      <number>4</number>
      </property>
      <column>
       <property name="text">
        <string>Name</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Flavor</string>
       </property>
      </column>
      <column>

--- a/src/modules/imageselection/SeapathFlavorSelection.ui
+++ b/src/modules/imageselection/SeapathFlavorSelection.ui
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>SeapathFlavorSelection</class>
+ <widget class="QDialog" name="SeapathFlavorSelection">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>454</width>
+    <height>192</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Installer cannot detect the SEAPATH flavor of the selected image.</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>436</width>
+       <height>36</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>Which SEAPATH flavor type is the selected image?</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QRadioButton" name="debianRadioButton">
+     <property name="text">
+      <string>SEAPATH Debian</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QRadioButton" name="yoctoRadioButton">
+     <property name="text">
+      <string>SEAPATH Yocto</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>SeapathFlavorSelection</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>SeapathFlavorSelection</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/modules/keyboard/SetKeyboardLayoutJob.cpp
+++ b/src/modules/keyboard/SetKeyboardLayoutJob.cpp
@@ -348,6 +348,7 @@ SetKeyboardLayoutJob::exec()
     Calamares::GlobalStorage* gs = Calamares::JobQueue::instance()->globalStorage();
 
     QString seapathFlavor = gs->value( "seapathFlavor" ).toString();
+    seapathFlavor = seapathFlavor.toLower();
 
     if (seapathFlavor == "yocto"){
         destDir = QDir( gs->value( "etcMountPoint" ).toString() );

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -158,6 +158,8 @@ def run():
     os.makedirs(persistent_mount_point, exist_ok=True)
 
     seapath_flavor = libcalamares.globalstorage.value("seapathFlavor")
+    seapath_flavor = seapath_flavor.lower()
+
     rootfs_partition, persistent_partition = get_partitions(target_disk, seapath_flavor)
     mount_partition(rootfs_partition, rootfs0_mount_point)
 

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -16,6 +16,7 @@
 import os
 import tempfile
 import subprocess
+import re
 
 import libcalamares
 
@@ -130,8 +131,15 @@ def get_partitions(device_name, seapath_flavor):
             libcalamares.utils.error(f"Failed to list partitions of {device_name}.")
             raise
 
-        rootfs_partition_index = partitions.index("/dev/mapper/vg1-root")
-        rootfs_partition = partitions[rootfs_partition_index]
+        rootfs_partition = next(
+            (p for p in partitions if re.match(r"^/dev/mapper/vg\d+-root$", p)),
+            None,
+        )
+        if not rootfs_partition:
+            libcalamares.utils.error(
+                "Failed to find root LVM partition matching /dev/mapper/vg*-root."
+            )
+            raise RuntimeError("Root LVM partition not found")
     else:
         rootfs_partition = partitions[3]
         persistent_partition = partitions[6]

--- a/src/modules/networkcfg/main.py
+++ b/src/modules/networkcfg/main.py
@@ -128,7 +128,10 @@ def run():
     """
     Setup network configuration
     """
-    if libcalamares.globalstorage.value("seapathFlavor") == "debian":
+    seapath_flavor = libcalamares.globalstorage.value("seapathFlavor")
+    seapath_flavor = seapath_flavor.lower()
+
+    if seapath_flavor == "debian":
         root_mount_point = libcalamares.globalstorage.value("rootMountPoint")
         etc_mount_point = root_mount_point + "/etc"
         remove_default_network_file(etc_mount_point)

--- a/src/modules/rawimage/main.py
+++ b/src/modules/rawimage/main.py
@@ -204,6 +204,7 @@ def run():
     gs = libcalamares.globalstorage
     image = gs.value("imageselection.selectedFiles")[0]
     seapath_flavor = libcalamares.globalstorage.value("seapathFlavor")
+    no_bmap = libcalamares.globalstorage.value("noBmap")
     seapath_flavor = seapath_flavor.lower()
 
     libcalamares.utils.debug("SEAPATH flavor selected: {}".format(seapath_flavor))
@@ -239,6 +240,9 @@ def run():
         # Run the script on the host; switch to target_env_process_output(),
         # if it must run in target chroot.
         bmaptool_cmd = ["bmaptool", "--debug", "copy"]
+
+        if no_bmap == "true":
+            bmaptool_cmd.append("--nobmap")
 
         bmaptool_cmd.extend([image, target_device])
         host_env_process_output(

--- a/src/modules/rawimage/main.py
+++ b/src/modules/rawimage/main.py
@@ -204,6 +204,7 @@ def run():
     gs = libcalamares.globalstorage
     image = gs.value("imageselection.selectedFiles")[0]
     seapath_flavor = libcalamares.globalstorage.value("seapathFlavor")
+    seapath_flavor = seapath_flavor.lower()
 
     libcalamares.utils.debug("SEAPATH flavor selected: {}".format(seapath_flavor))
     libcalamares.utils.debug(f"Selected image: {image}")

--- a/src/modules/sshkeyselection/SshKeySelectionJob.cpp
+++ b/src/modules/sshkeyselection/SshKeySelectionJob.cpp
@@ -24,6 +24,7 @@ SshKeySelectionJob::exec()
     QStringList users = { "admin", "ansible" };
     Calamares::GlobalStorage* gs = Calamares::JobQueue::instance()->globalStorage();
     QString seapathFlavor = gs->value( "seapathFlavor" ).toString();
+    seapathFlavor = seapathFlavor.toLower();
     cDebug() << "SshKeySelectionJob: Seapath flavor:" << seapathFlavor;
 
     if (seapathFlavor == "yocto"){

--- a/src/modules/umount/UmountJob.cpp
+++ b/src/modules/umount/UmountJob.cpp
@@ -139,6 +139,7 @@ UmountJob::exec()
         = Calamares::JobQueue::instance() ? Calamares::JobQueue::instance()->globalStorage() : nullptr;
 
     QString seapathFlavor = gs->value("seapathFlavor").toString();
+    seapathFlavor = seapathFlavor.toLower();
     if ( !gs )
     {
         return Calamares::JobResult::internalError(


### PR DESCRIPTION
Hello,
This PR adds many modification to prepare the upcoming release of SEAPATH 2.0:

- Fix broken compatibility with older SEAPATH Debian version 
- Add support of images metadata, though image bmap file, instead of JSON files
- Add `Flavor` column in image selection, which indicate what SEAPATH flavor (Yocto, Debian) the image is
- Add `Setup` column in image selection, which indicate what SEAPATH setup (standalone, cluster) the image is
- Add a UI prompt to select the SEAPATH flavor if installer cannot detect it
- Add support for image installation without bmap file