### PR TITLE
branding: bump version to 1.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,9 @@ For more information about the upstream Calamares project, visit
 https://calamares.euroquis.nl/
 
 # Release notes
+## Version 1.2.2
+* Remove version from welcome screen to avoid confusion between the version
+  of the installer and the version of the images
 ## Version 1.2.1
 * Fix segfault when no partitions are on the selected disk
 * Fix error when multiple lvm volume group are present on the machine

--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,7 @@
 export DESTDIR=/tmp/sysroot-seapath-installer
 export BUILDDIR=./build
 export CMAKE_ARGS="-DWITH_QT6=OFF"
-export VERSION="1.2.1"
+export VERSION="1.2.2"
 ./ci/build.sh
 mkdir -p seapath-installer_${VERSION}_all/etc/calamares
 mkdir -p seapath-installer_${VERSION}_all/usr/share/calamares/modules

--- a/debian/DEBIAN/control
+++ b/debian/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: seapath-installer
-Version: 1.2.1
+Version: 1.2.2
 Architecture: all
 Essential: no
 Priority: optional

--- a/src/branding/seapath/branding.desc
+++ b/src/branding/seapath/branding.desc
@@ -123,10 +123,10 @@ navigation: widget
 strings:
     productName:         "LFEnergy SEAPATH"
     shortProductName:    "SEAPATH"
-    version:             1.2.1
-    shortVersion:        1.2.1
-    versionedName:       LFEnergy SEAPATH 1.2.1
-    shortVersionedName:  SEAPATH 1.2.1
+    version:             1.2.2
+    shortVersion:        1.2.2
+    versionedName:       LFEnergy SEAPATH
+    shortVersionedName:  SEAPATH 1.2.2
     bootloaderEntryName: SEAPATH
     productUrl:          https://lfenergy.org/projects/seapath/
     supportUrl:          https://lf-energy.atlassian.net/wiki/spaces/SEAP/overview


### PR DESCRIPTION
Also remove the version from the versionedName field. It allows to display "Welcome to the LFEnergy SEAPATH installer" instead of "Welcome to the LFEnergy SEAPATH vX.Y.Z installer"