### PR TITLE
brandings: change welcome message

### DIFF
--- a/src/branding/seapath/branding.desc
+++ b/src/branding/seapath/branding.desc
@@ -125,7 +125,7 @@ strings:
     shortProductName:    "SEAPATH"
     version:             1.2.1
     shortVersion:        1.2.1
-    versionedName:       LFEnergy SEAPATH 1.2.1
+    versionedName:       LFEnergy SEAPATH
     shortVersionedName:  SEAPATH 1.2.1
     bootloaderEntryName: SEAPATH
     productUrl:          https://lfenergy.org/projects/seapath/


### PR DESCRIPTION
Remove installer version number from the welcome message version, as this can be confusing with the version of the SEAPATH images.