### PR TITLE
workflows: trigger release on published, not created

### DIFF
--- a/.github/workflows/publish-release-deb.yml
+++ b/.github/workflows/publish-release-deb.yml
@@ -2,7 +2,7 @@ name: Build and publish seapath-installer deb on release
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 permissions:
   contents: write


### PR DESCRIPTION
Some releases are first saved at draft before beeing published. What we really want is the workflow to be triggered when the release is published.