### PR TITLE
Integrate SEAPATH SLES to code and UI

### DIFF
--- a/src/modules/imageselection/ImageSelectionPage.cpp
+++ b/src/modules/imageselection/ImageSelectionPage.cpp
@@ -250,7 +250,20 @@ ImageSelectionPage::confirmSeapathFlavor()
     ui.setupUi( dlg.data() );
     dlg->exec();
 
-    auto seapathFlavor = ui.debianRadioButton->isChecked() ? "debian" : "yocto";
+    QString seapathFlavor;
+
+    if ( ui.debianRadioButton->isChecked() )
+    {
+        seapathFlavor = "debian";
+    }
+    else if ( ui.slesRadioButton->isChecked() )
+    {
+        seapathFlavor = "sles";
+    }
+    else
+    {
+        seapathFlavor = "yocto";
+    }
     cDebug() << "Selected SEAPATH flavor:" << seapathFlavor;
 
     gs->insert( "seapathFlavor", seapathFlavor );

--- a/src/modules/imageselection/SeapathFlavorSelection.ui
+++ b/src/modules/imageselection/SeapathFlavorSelection.ui
@@ -62,6 +62,13 @@
     </widget>
    </item>
    <item row="5" column="0">
+    <widget class="QRadioButton" name="slesRadioButton">
+     <property name="text">
+      <string>SEAPATH SLES</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="enabled">
       <bool>true</bool>

--- a/src/modules/keyboard/SetKeyboardLayoutJob.cpp
+++ b/src/modules/keyboard/SetKeyboardLayoutJob.cpp
@@ -352,10 +352,9 @@ SetKeyboardLayoutJob::exec()
 
     if (seapathFlavor == "yocto"){
         destDir = QDir( gs->value( "etcMountPoint" ).toString() );
-
     }
-
-    else if (seapathFlavor == "debian"){
+    else
+    {
         destDir = QDir( gs->value( "rootMountPoint" ).toString() );
         destDir.cd( "etc" );
     }

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -96,8 +96,8 @@ def get_partitions(device_name, seapath_flavor):
     nvme0n1p4
     nvme0n1p5
     nvme0n1p6
-    If the flavor is debian, roofs is the second one. If the flavor is seapath
-    rootfs is third and the persistentfs is sixth.
+    If the flavor is yocto, rootfs is third partition and the persistentfs is the sixth.
+    For other flavors, the second partition is a volume group containing the rootfs as a logical volume.
 
     Returns rootfs and persistent partitions name as string.
     """
@@ -115,7 +115,11 @@ def get_partitions(device_name, seapath_flavor):
 
     libcalamares.utils.debug(f"List of partitions for {device_name}: {partitions}")
     persistent_partition = ""
-    if seapath_flavor == "debian":
+
+    if seapath_flavor == "yocto":
+        rootfs_partition = partitions[3]
+        persistent_partition = partitions[6]
+    else:
         enable_lv()
 
         # We need to refresh the partition list after enabling LVM
@@ -140,9 +144,7 @@ def get_partitions(device_name, seapath_flavor):
                 "Failed to find root LVM partition matching /dev/mapper/vg*-root."
             )
             raise RuntimeError("Root LVM partition not found")
-    else:
-        rootfs_partition = partitions[3]
-        persistent_partition = partitions[6]
+
     return rootfs_partition, persistent_partition
 
 

--- a/src/modules/networkcfg/main.py
+++ b/src/modules/networkcfg/main.py
@@ -131,12 +131,12 @@ def run():
     seapath_flavor = libcalamares.globalstorage.value("seapathFlavor")
     seapath_flavor = seapath_flavor.lower()
 
-    if seapath_flavor == "debian":
+    if seapath_flavor == "yocto":
+        etc_mount_point = libcalamares.globalstorage.value("etcMountPoint")
+    else:
         root_mount_point = libcalamares.globalstorage.value("rootMountPoint")
         etc_mount_point = root_mount_point + "/etc"
         remove_default_network_file(etc_mount_point)
-    else:
-        etc_mount_point = libcalamares.globalstorage.value("etcMountPoint")
 
     if etc_mount_point is None:
         libcalamares.utils.warning(

--- a/src/modules/sshkeyselection/SshKeySelectionJob.cpp
+++ b/src/modules/sshkeyselection/SshKeySelectionJob.cpp
@@ -30,18 +30,12 @@ SshKeySelectionJob::exec()
     if (seapathFlavor == "yocto"){
         destDir = QDir( gs->value( "homeMountPoint" ).toString() );
     }
-
-    else if (seapathFlavor == "debian"){
+    else
+    {
         destDir = QDir( gs->value( "rootMountPoint" ).toString() );
         destDir.cd("home");
-        cDebug() << "SshKeySelectionJob: Debian root mount point:" << destDir.absolutePath();
     }
-    else {
-        cError() << "SshKeySelectionJob: Unknown Seapath flavor:" << seapathFlavor;
-        return Calamares::JobResult::error(
-            tr("Failed to determine Seapath flavor.", "@error"),
-            tr("Unknown Seapath flavor: %1.", "@error, %1 is the Seapath flavor").arg(seapathFlavor));
-    }
+    cDebug() << "SshKeySelectionJob: Mount point:" << destDir.absolutePath();
 
     for (const QString& user : users) {
         dotSSHConfPath.append(destDir.absoluteFilePath(user + QStringLiteral("/.ssh")));

--- a/src/modules/umount/UmountJob.cpp
+++ b/src/modules/umount/UmountJob.cpp
@@ -137,14 +137,14 @@ UmountJob::exec()
 
     Calamares::GlobalStorage* gs
         = Calamares::JobQueue::instance() ? Calamares::JobQueue::instance()->globalStorage() : nullptr;
-
-    QString seapathFlavor = gs->value("seapathFlavor").toString();
-    seapathFlavor = seapathFlavor.toLower();
     if ( !gs )
     {
         return Calamares::JobResult::internalError(
             "UMount", tr( "GlobalStorage is not available." ), Calamares::JobResult::InvalidConfiguration );
     }
+
+    QString seapathFlavor = gs->value("seapathFlavor").toString();
+    seapathFlavor = seapathFlavor.toLower();
 
     // Factorized list of mount point keys to process in order.
     const QList<QString> mountKeys { "rootMountPoint", "persistentMountPoint", "homeMountPoint", "etcMountPoint" };

--- a/src/modules/umount/UmountJob.cpp
+++ b/src/modules/umount/UmountJob.cpp
@@ -152,7 +152,7 @@ UmountJob::exec()
     {
         QString mp = gs->value( key ).toString();
 
-        if (seapathFlavor == "debian" && key == "persistentMountPoint") {
+        if (seapathFlavor != "yocto" && key == "persistentMountPoint") {
             // Persistent mount point is exclusive of Yocto flavor
             continue;
         }


### PR DESCRIPTION
* Adapt flavor handling to use "the Debian-way" as the default. This makes it easier to integrate SEAPATH SLES in the installer, but will also ease integration of future SEAPATH flavors
* Add SEAPATH SLES option in the flavor selection window when no flavor is detected